### PR TITLE
fold inactivity_shortcut to zero for genesis/shallow/pre-hardening bl…

### DIFF
--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -787,18 +787,23 @@ impl VirtualStateProcessor {
     }
 
     /// KIP-21: block hash of the highest chain block at
-    /// `bs <= ghostdag_data.blue_score - finality_depth - 1`. The
-    /// committed `inactivity_shortcut` value is this block's seq_commit (see
+    /// `bs <= ghostdag_data.blue_score - finality_depth - 1`. The committed
+    /// `inactivity_shortcut` value is this block's seq_commit (see
     /// [`Self::inactivity_shortcut`]).
-    /// Returns `ZERO_HASH` when the block is too early for any shortcut
-    /// (`bs <= finality_depth`)
+    ///
+    /// Never returns `ZERO_HASH`. Before a real shortcut block is reachable
+    /// (early chain, or within finality depth of hardening activation), a
+    /// pre-hardening stand-in is returned. Such stand-ins are valid for
+    /// context-hash recomputation but must not be exposed to provers or RPC
+    /// consumers as real shortcut targets.
     pub(super) fn compute_inactivity_shortcut_block(&self, ghostdag_data: &GhostdagData) -> Hash {
+        let selected_parent = ghostdag_data.selected_parent;
+
         if ghostdag_data.blue_score < self.finality_depth + 1 {
-            return ZERO_HASH;
+            return selected_parent;
         }
 
         let target_bs = ghostdag_data.blue_score - self.finality_depth - 1;
-        let selected_parent = ghostdag_data.selected_parent;
 
         let coinbase_lk = kaspa_seq_commit::hashing::lane_key(&kaspa_consensus_core::subnets::SUBNETWORK_ID_COINBASE.into_bytes());
         let bounds = SmtReadBounds::new(target_bs, 0);
@@ -811,26 +816,19 @@ impl VirtualStateProcessor {
             // Post-IBD boundary, "exact at pp": target_bs == pp.bs
             Some(_zero) => {}
             // Post-IBD boundary, "below pp": target_bs < pp.bs and no coinbase
-            // entry exists at that depth in our SMT. Seed from the pp's stored
-            // shortcut and walk forward to target_bs.
+            // entry exists at that depth in our SMT. Fall through to seed the
+            // forward walk from the selected parent's recorded shortcut.
             None => {}
         };
 
-        if selected_parent == self.genesis.hash {
-            return ZERO_HASH;
-        }
+        let search_from = self
+            .smt_metadata_store
+            .get(selected_parent)
+            .map(|md| md.inactivity_shortcut_block())
+            .optional()
+            .unwrap()
+            .unwrap_or(selected_parent);
 
-        let search_from = if let Some(sp_inactivity_shortcut_block) =
-            self.smt_metadata_store.get(selected_parent).map(|md| md.inactivity_shortcut_block()).optional().unwrap()
-            && sp_inactivity_shortcut_block != ZERO_HASH
-        {
-            sp_inactivity_shortcut_block
-        } else {
-            self.headers_store.get_header(selected_parent).unwrap().pruning_point
-        };
-
-        let bs_start = self.headers_store.get_blue_score(search_from).unwrap_or(0); // zero for genesis case
-        assert!(bs_start <= target_bs);
         let mut current = search_from;
         for chain_block in self.reachability_service.forward_chain_iterator(current, selected_parent, true).skip(1) {
             if self.headers_store.get_blue_score(chain_block).unwrap() > target_bs {
@@ -842,13 +840,24 @@ impl VirtualStateProcessor {
     }
 
     /// Derive the `inactivity_shortcut` value committed in
-    /// `MergesetContext.inactivity_shortcut` from its block hash. `ZERO_HASH`
-    /// (no block known) and genesis both yield `ZERO_HASH`.
+    /// `MergesetContext.inactivity_shortcut` from its block hash. Folds to
+    /// `ZERO_HASH` whenever the block cannot be a real shortcut target:
+    /// genesis, blocks too shallow for any block to be at depth
+    /// `finality_depth + 1` past them, or pre-hardening blocks (whose
+    /// seq_commit does not encode a shortcut). Otherwise returns the block's
+    /// seq_commit.
+    ///
+    /// Panics on `ZERO_HASH` input — callers must pass a real block hash.
     pub(super) fn inactivity_shortcut(&self, inactivity_shortcut_block: Hash) -> Hash {
-        if inactivity_shortcut_block == ZERO_HASH || inactivity_shortcut_block == self.genesis.hash {
+        assert_ne!(inactivity_shortcut_block, ZERO_HASH, "inactivity_shortcut block must be a real block hash");
+        if inactivity_shortcut_block == self.genesis.hash {
             return ZERO_HASH;
         }
-        self.headers_store.get_header(inactivity_shortcut_block).unwrap().accepted_id_merkle_root
+        let header = self.headers_store.get_header(inactivity_shortcut_block).unwrap();
+        if header.blue_score < self.finality_depth + 1 || !self.zk_hardening_activation.is_active(header.daa_score) {
+            return ZERO_HASH;
+        }
+        header.accepted_id_merkle_root
     }
 
     /// Get the parent's lanes_root, active_lanes_count, and inactivity_shortcut_block.

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -354,26 +354,27 @@ fn inactivity_shortcut_config() -> kaspa_consensus_core::config::Config {
 }
 
 /// Blocks with `bs <= finality_depth` have no resolvable shortcut yet;
-/// the recorded `inactivity_shortcut_block` is `ZERO_HASH`.
+/// the recorded `inactivity_shortcut_block` is the selected parent (a
+/// pre-hardening stand-in whose seq_commit folds to `ZERO_HASH`).
 #[tokio::test]
-async fn inactivity_shortcut_block_is_zero_within_finality_depth() {
+async fn inactivity_shortcut_block_stands_in_with_sp_within_finality_depth() {
     let config = inactivity_shortcut_config();
     let mut ctx = TestContext::new(TestConsensus::new(&config));
     let finality_depth = config.finality_depth();
     assert_eq!(finality_depth, 2);
 
-    // Mine B1, B2 - both have bs ∈ {1, 2} ≤ finality_depth.
     let mut chain = vec![config.genesis.hash];
     for _ in 0..2 {
         ctx.build_block_template_row(0..1).validate_and_insert_row().await;
         chain.push(ctx.consensus.get_sink());
     }
 
-    for hash in chain.iter().copied().skip(1) {
+    for (i, hash) in chain.iter().copied().enumerate().skip(1) {
         let header = ctx.consensus.get_header(hash).unwrap();
         assert!(header.blue_score <= finality_depth);
         let meta = ctx.consensus.smt_block_metadata(hash);
-        assert_eq!(meta.inactivity_shortcut_block(), kaspa_hashes::ZERO_HASH, "bs={}", header.blue_score);
+        let expected_sp = chain[i - 1];
+        assert_eq!(meta.inactivity_shortcut_block(), expected_sp, "bs={}", header.blue_score);
     }
 }
 

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -711,17 +711,25 @@ impl IbdFlow {
         // headers_store, then verify against pp_header's seq_commit.
         let md = stream.recv_metadata().await?;
         let parent_header = consensus.async_get_header(pp_header.direct_parents()[0]).await.unwrap();
-        // Resolve inactivity_shortcut iff this pruning point is post-activation; pre-activation
-        // blocks didn't commit it, so the verifier must also omit it from `mergeset_context_hash`.
+        // Mirrors consensus-side `inactivity_shortcut()`: gate on hardening
+        // activation for the pp itself; for the referenced shortcut block,
+        // fold to ZERO_HASH on genesis, blocks too shallow for a real
+        // shortcut depth, or pre-hardening daa_score.
         let inactivity_shortcut = if self.ctx.config.zk_hardening_activation.is_active(pp_header.daa_score) {
-            let shortcut = if md.inactivity_shortcut_block == kaspa_hashes::ZERO_HASH {
+            let shortcut = if md.inactivity_shortcut_block == self.ctx.config.genesis.hash {
                 kaspa_hashes::ZERO_HASH
             } else {
-                consensus
+                let shortcut_header = consensus
                     .async_get_header(md.inactivity_shortcut_block)
                     .await
-                    .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block header not found: {e}")))?
-                    .accepted_id_merkle_root
+                    .map_err(|e| ProtocolError::OtherOwned(format!("inactivity_shortcut_block header not found: {e}")))?;
+                if shortcut_header.blue_score < self.ctx.config.finality_depth() + 1
+                    || !self.ctx.config.zk_hardening_activation.is_active(shortcut_header.daa_score)
+                {
+                    kaspa_hashes::ZERO_HASH
+                } else {
+                    shortcut_header.accepted_id_merkle_root
+                }
             };
             Some(shortcut)
         } else {

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -1493,10 +1493,17 @@ fn chain_seq_commit_context_hash(consensus: &TestConsensus, accepting_block: Has
 }
 
 fn inactivity_shortcut_for(consensus: &TestConsensus, inactivity_shortcut_block: Hash) -> Hash {
-    if inactivity_shortcut_block == kaspa_hashes::ZERO_HASH || inactivity_shortcut_block == consensus.params().genesis.hash {
+    assert_ne!(inactivity_shortcut_block, kaspa_hashes::ZERO_HASH);
+    if inactivity_shortcut_block == consensus.params().genesis.hash {
         return kaspa_hashes::ZERO_HASH;
     }
-    consensus.get_header(inactivity_shortcut_block).unwrap().accepted_id_merkle_root
+    let header = consensus.get_header(inactivity_shortcut_block).unwrap();
+    if header.blue_score < consensus.params().finality_depth() + 1
+        || !consensus.params().zk_hardening_activation.is_active(header.daa_score)
+    {
+        return kaspa_hashes::ZERO_HASH;
+    }
+    header.accepted_id_merkle_root
 }
 
 fn assert_chain_seq_commit_lane(consensus: &TestConsensus, accepting_block: Hash, activity: &ChainSeqCommitLaneActivity) {


### PR DESCRIPTION
…ocks

Drop PP-walk fallback; use SP as the recorded shortcut-block stand-in when no real shortcut exists yet. Resolve the committed value via inactivity_shortcut() which folds to ZERO_HASH on genesis, blocks with bs < finality_depth + 1, or pre-hardening daa_score. Mirror the same folding on the IBD pp-metadata verifier.